### PR TITLE
Fix #27 by casting literal strings to varchar in projection lists only

### DIFF
--- a/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
+++ b/src/EntityFramework6.Npgsql/EntityFramework6.Npgsql.csproj
@@ -69,6 +69,7 @@
     <Compile Include="NpgsqlServices.cs" />
     <Compile Include="NpgsqlProviderManifest.cs" />
     <Compile Include="NpgsqlTextFunctions.cs" />
+    <Compile Include="NpgsqlTypeFunctions.cs" />
     <Compile Include="NpgsqlWeightLabel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Spatial\PostgisDataReader.cs" />

--- a/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlProviderManifest.cs
@@ -351,15 +351,15 @@ namespace Npgsql
         public override bool SupportsInExpression() => true;
 
         public override ReadOnlyCollection<EdmFunction> GetStoreFunctions()
-            => typeof(NpgsqlTextFunctions).GetTypeInfo()
-                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            => new[] { typeof(NpgsqlTextFunctions).GetTypeInfo(), typeof(NpgsqlTypeFunctions) }
+                .SelectMany(x => x.GetMethods(BindingFlags.Public | BindingFlags.Static))
                 .Select(x => new { Method = x, DbFunction = x.GetCustomAttribute<DbFunctionAttribute>() })
                 .Where(x => x.DbFunction != null)
-                .Select(x => CreateFullTextEdmFunction(x.Method, x.DbFunction))
+                .Select(x => CreateComposableEdmFunction(x.Method, x.DbFunction))
                 .ToList()
                 .AsReadOnly();
 
-        static EdmFunction CreateFullTextEdmFunction([NotNull] MethodInfo method, [NotNull] DbFunctionAttribute dbFunctionInfo)
+        static EdmFunction CreateComposableEdmFunction([NotNull] MethodInfo method, [NotNull] DbFunctionAttribute dbFunctionInfo)
         {
             if (method == null)
                 throw new ArgumentNullException(nameof(method));

--- a/src/EntityFramework6.Npgsql/NpgsqlTypeFunctions.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlTypeFunctions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Data.Entity;
+
+namespace Npgsql
+{
+    /// <summary>
+    /// Use this class in LINQ queries to emit type manipulation SQL fragments.
+    /// </summary>
+    public static class NpgsqlTypeFunctions
+    {
+        /// <summary>
+        /// Emits an explicit cast for unknown types sent as strings to their correct postgresql type.
+        /// </summary>
+        [DbFunction("Npgsql", "cast")]
+        public static string Cast(string unknownTypeValue, string postgresTypeName)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/test/EntityFramework6.Npgsql.Tests/Support/EntityFrameworkTestBase.cs
+++ b/test/EntityFramework6.Npgsql.Tests/Support/EntityFrameworkTestBase.cs
@@ -104,6 +104,20 @@ namespace EntityFramework6.Npgsql.Tests
         public int Id { get; set; }
     }
 
+    [Table("Users")]
+    public abstract class User
+    {
+        public int Id { get; set; }
+
+        public IList<Blog> Blogs { get; set; }
+    }
+
+    [Table("Editors")]
+    public class Editor : User { }
+
+    [Table("Administrators")]
+    public class Administrator : User { }
+
     public class BloggingContext : DbContext
     {
         public BloggingContext(string connection)
@@ -114,6 +128,9 @@ namespace EntityFramework6.Npgsql.Tests
         public DbSet<Blog> Blogs { get; set; }
         public DbSet<Post> Posts { get; set; }
         public DbSet<NoColumnsEntity> NoColumnsEntities { get; set; }
+        public DbSet<User> Users { get; set; }
+        public DbSet<Editor> Editors { get; set; }
+        public DbSet<Administrator> Administrators { get; set; }
 
         [DbFunction("BloggingContext", "ClrStoredAddFunction")]
         public static int StoredAddFunction(int val1, int val2)
@@ -135,6 +152,9 @@ namespace EntityFramework6.Npgsql.Tests
             dbModelBuilder.Entity<Blog>();
             dbModelBuilder.Entity<Post>();
             dbModelBuilder.Entity<NoColumnsEntity>();
+            dbModelBuilder.Entity<User>();
+            dbModelBuilder.Entity<Editor>();
+            dbModelBuilder.Entity<Administrator>();
 
             // Import function
             var dbModel = dbModelBuilder.Build(connection);


### PR DESCRIPTION
This fixes bug #27 with a tiny behavioral change that would only rarely affect unlikely query scenarios. And in that case a workaround is possible by just using an explicit cast.