### PR TITLE
Remove explicit default value for not nullable columns

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
@@ -596,14 +596,6 @@ namespace Npgsql
                         break;
                 }
             }
-            else if (column.IsNullable != null
-                && !column.IsNullable.Value
-                && (column.StoreType == null ||
-                (column.StoreType.IndexOf("rowversion", StringComparison.OrdinalIgnoreCase) == -1)))
-            {
-                sql.Append(" DEFAULT ");
-                AppendValue(column.ClrDefaultValue, sql);
-            }
         }
 
         private void AppendColumnType(ColumnModel column, StringBuilder sql, bool setSerial)

--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkMigrationTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkMigrationTests.cs
@@ -151,13 +151,13 @@ namespace EntityFramework6.Npgsql.Tests
                                     expectedColumns.Remove((string)reader[0]);
                                     Assert.AreEqual("integer", (string)reader[1]);
                                     Assert.AreEqual("NO", (string)reader[2]);
-                                    Assert.AreEqual("0", (string)reader[3]);
+                                    Assert.That(string.IsNullOrEmpty(reader[3] as string));
                                     break;
                                 case "UniqueId":
                                     expectedColumns.Remove((string)reader[0]);
                                     Assert.AreEqual("uuid", (string)reader[1]);
                                     Assert.AreEqual("NO", (string)reader[2]);
-                                    Assert.AreEqual("'00000000-0000-0000-0000-000000000000'::uuid", reader[3] as string);
+                                    Assert.That(string.IsNullOrEmpty(reader[3] as string));
                                     //Assert.AreEqual("uuid_generate_v4()", reader[3] as string);
                                     break;
                                 case "Rating":
@@ -358,7 +358,7 @@ namespace EntityFramework6.Npgsql.Tests
                 Assert.AreEqual("CREATE SCHEMA IF NOT EXISTS someSchema", statments.ElementAt(0).Sql);
             else
                 Assert.AreEqual("CREATE SCHEMA someSchema", statments.ElementAt(0).Sql);
-            Assert.AreEqual("CREATE TABLE \"someSchema\".\"someTable\"(\"SomeString\" varchar(233) NOT NULL DEFAULT '',\"AnotherString\" text,\"SomeBytes\" bytea,\"SomeLong\" serial8,\"SomeDateTime\" timestamp)", statments.ElementAt(1).Sql);
+            Assert.AreEqual("CREATE TABLE \"someSchema\".\"someTable\"(\"SomeString\" varchar(233) NOT NULL,\"AnotherString\" text,\"SomeBytes\" bytea,\"SomeLong\" serial8,\"SomeDateTime\" timestamp)", statments.ElementAt(1).Sql);
         }
 
         [Test]


### PR DESCRIPTION
System.Data.SqlClient never adds default when it is not setted.

CREATE TABLE "Project_Administrator"("Id" uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000',
vs
CREATE TABLE [Project_Administrator] (
    [Id] [uniqueidentifier] NOT NULL,