### PR TITLE
Fix test regression due to #77

### DIFF
--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkBasicTests.cs
@@ -87,12 +87,6 @@ namespace EntityFramework6.Npgsql.Tests
         {
             using (var context = new BloggingContext(ConnectionString))
             {
-                context.Database.Delete();
-                context.Database.Create();
-            }
-
-            using (var context = new BloggingContext(ConnectionString))
-            {
                 context.NoColumnsEntities.Add(new NoColumnsEntity());
                 context.SaveChanges();
             }

--- a/test/EntityFramework6.Npgsql.Tests/Support/EntityFrameworkTestBase.cs
+++ b/test/EntityFramework6.Npgsql.Tests/Support/EntityFrameworkTestBase.cs
@@ -73,6 +73,7 @@ namespace EntityFramework6.Npgsql.Tests
             {
                 context.Blogs.RemoveRange(context.Blogs);
                 context.Posts.RemoveRange(context.Posts);
+                context.NoColumnsEntities.RemoveRange(context.NoColumnsEntities);
                 context.SaveChanges();
             }
         }


### PR DESCRIPTION
@roji This fixes the broken tests. The reason was that in the test ```InsertAndSelectSchemaless``` I was mistakenly dropping / recreating the database without running the rest of the code that created the sequence / adding the stored procedure. The test is now cleaned up and all tests pass.