### PR TITLE
Make ALTER INDEX RENAME TO migration operation consistent with CREATE…

### DIFF
--- a/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
+++ b/src/EntityFramework6.Npgsql/NpgsqlMigrationSqlGenerator.cs
@@ -426,9 +426,9 @@ namespace Npgsql
 
             sql.Append(GetSchemaNameFromFullTableName(renameIndexOperation.Table));
             sql.Append(".\"");
-            sql.Append(renameIndexOperation.Name);
+            sql.Append(GetTableNameFromFullTableName(renameIndexOperation.Table) + "_" + renameIndexOperation.Name);
             sql.Append("\" RENAME TO \"");
-            sql.Append(renameIndexOperation.NewName);
+            sql.Append(GetTableNameFromFullTableName(renameIndexOperation.Table) + "_" + renameIndexOperation.NewName);
             sql.Append('"');
             AddStatment(sql);
         }

--- a/test/EntityFramework6.Npgsql.Tests/EntityFrameworkMigrationTests.cs
+++ b/test/EntityFramework6.Npgsql.Tests/EntityFrameworkMigrationTests.cs
@@ -487,11 +487,11 @@ namespace EntityFramework6.Npgsql.Tests
             Assert.AreEqual(1, statements.Count());
             if (_backendVersion.Major > 9 || (_backendVersion.Major == 9 && _backendVersion.Minor >= 2))
             {
-                Assert.AreEqual("ALTER INDEX IF EXISTS someSchema.\"someOldIndexName\" RENAME TO \"someNewIndexName\"", statements.ElementAt(0).Sql);
+                Assert.AreEqual("ALTER INDEX IF EXISTS someSchema.\"someTable_someOldIndexName\" RENAME TO \"someTable_someNewIndexName\"", statements.ElementAt(0).Sql);
             }
             else
             {
-                Assert.AreEqual("ALTER INDEX someSchema.\"someOldIndexName\" RENAME TO \"someNewIndexName\"", statements.ElementAt(0).Sql);    
+                Assert.AreEqual("ALTER INDEX someSchema.\"someTable_someOldIndexName\" RENAME TO \"someTable_someNewIndexName\"", statements.ElementAt(0).Sql);    
             }
         }
 


### PR DESCRIPTION
… INDEX and DROP INDEX:

CREATE/DROP INDEX adds name of table to name of index. ALTER INDEX RENAME TO should do the same.

This issue may manifest itself as 42P07 'Relation already exists' error during automatic migration with complex index changes.
This issue may be masked due to the fact ALTER INDEX statement has 'IF EXISTS' clause.