### PR TITLE
Add check for null db parameter value

### DIFF
--- a/EF6.PG/NpgsqlServices.cs
+++ b/EF6.PG/NpgsqlServices.cs
@@ -60,6 +60,11 @@ namespace Npgsql
         // Npgsql > 4.0 does strict type checks on integral values and fails with enums passed with numeric DbType.
         static void ConvertValueToNumericIfEnum(DbParameter parameter)
         {
+            if (parameter.Value == null)
+            {
+                return;
+            }
+
             var parameterValueObjectType = parameter.Value.GetType();
 
             if (!parameterValueObjectType.IsEnum)


### PR DESCRIPTION
Code inside ConvertValueToNumericIfEnumr throws null reference exception on null parameter value. I've tried to find confirmation that this value cannot be null but with no luck. In EF 6 sources null in parameter value treated equally to DbNull mostly and there are many null checks. Also i want to note that calling EF code has checks for null for two out of three parameters (DbProviderServices.SetDbParameterValue checks null for parameter and parameterType but not for value - https://github.com/dotnet/ef6/blob/master/src/EntityFramework/Core/Common/DbProviderServices.cs#L521). So i believe null is a valid value so this check is necessary here. 

Also it will fix this issue: https://github.com/npgsql/EntityFramework6.Npgsql/issues/126