### PR TITLE
#180 : use `PostgreSqlVersion.ToString()`

### DIFF
--- a/EF6.PG/NpgsqlServices.cs
+++ b/EF6.PG/NpgsqlServices.cs
@@ -114,7 +114,7 @@ namespace Npgsql
 
             var serverVersion = "";
             UsingPostgresDbConnection((NpgsqlConnection)connection, conn => {
-                serverVersion = conn.ServerVersion;
+                serverVersion = conn.PostgreSqlVersion.ToString();
             });
             return serverVersion;
         }


### PR DESCRIPTION
Hi,
Thanks for the project, it is awesome. As we are still stuck with EF6, I stumbled upon the same problem as in issue #180 while using Postgres in a docker container hosted in a debian VM.
Here is a proposed fix for that problem.
Kind regards,
Hugues