### PR TITLE
7.0.x provider compatibility

### DIFF
--- a/EF6.PG/NpgsqlMigrationSqlGenerator.cs
+++ b/EF6.PG/NpgsqlMigrationSqlGenerator.cs
@@ -725,14 +725,14 @@ namespace Npgsql
         void AppendValue(DateTime value, StringBuilder sql)
         {
             sql.Append("'");
-            sql.Append(new NpgsqlTypes.NpgsqlDateTime(value));
+            sql.Append(value.ToString("yyyy-MM-dd HH:mm:ss.fffffff"));
             sql.Append("'");
         }
 
         void AppendValue(DateTimeOffset value, StringBuilder sql)
         {
             sql.Append("'");
-            sql.Append(new NpgsqlTypes.NpgsqlDateTime(value.UtcDateTime));
+            sql.Append(value.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff"));
             sql.Append("'");
         }
 
@@ -753,7 +753,8 @@ namespace Npgsql
         void AppendValue(TimeSpan value, StringBuilder sql)
         {
             sql.Append("'");
-            sql.Append(new NpgsqlTypes.NpgsqlTimeSpan(value));
+            sql.Append(value < TimeSpan.Zero ? "-" : "");
+            sql.Append(value.ToString(@"\P%d\D\T%h\H%m\M%s\S", CultureInfo.InvariantCulture));
             sql.Append("'");
         }
 

--- a/EF6.PG/NpgsqlServices.cs
+++ b/EF6.PG/NpgsqlServices.cs
@@ -107,6 +107,9 @@ namespace Npgsql
             sqlGenerator.BuildCommand(command);
         }
 
+        //Some server instances/npgsql provider versions return additional information after the server version.
+        //This regex is used to extract only version at the beginning of the string
+        private static Regex VersionRx = new Regex(@"^[0-9]+(?:\.[0-9]+){0,3}", RegexOptions.Compiled);
         protected override string GetDbProviderManifestToken([NotNull] DbConnection connection)
         {
             if (connection == null)
@@ -116,7 +119,7 @@ namespace Npgsql
             UsingPostgresDbConnection((NpgsqlConnection)connection, conn => {
                 serverVersion = conn.ServerVersion;
             });
-            return serverVersion;
+            return VersionRx.Match(serverVersion ?? "").ToString();
         }
 
         protected override DbProviderManifest GetDbProviderManifest([NotNull] string versionHint)

--- a/EF6.PG/SqlGenerators/VisitedExpression.cs
+++ b/EF6.PG/SqlGenerators/VisitedExpression.cs
@@ -183,7 +183,10 @@ namespace Npgsql.SqlGenerators
                 sqlText.Append("E'").Append(((string)_value).Replace(@"\", @"\\").Replace("'", @"\'")).Append("'");
                 break;
             case PrimitiveTypeKind.Time:
-                sqlText.AppendFormat(ni, "INTERVAL '{0}'", (NpgsqlTimeSpan)(TimeSpan)_value);
+                sqlText.Append("INTERVAL '");
+                if ((TimeSpan)_value < TimeSpan.Zero) sqlText.Append("-");
+                sqlText.Append(((TimeSpan)_value).ToString(@"\P%d\D\T%h\H%m\M%s\S", CultureInfo.InvariantCulture));
+                sqlText.Append('\'');
                 break;
             default:
                 // TODO: must support more constant value types.


### PR DESCRIPTION
1. Some server instances / provider versions return additional in server version string, which must be removed in order for server version to be serializable with "Version" class.
2. Removed usage of "NpgSqlDateTime" and "NpgSqlTimeSpan" classes in order to work with latest 7.0.x provider version
3. Needs "AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);" or migration of database's "timestamp" columns to "timestamtz" as described in the 6.0 documentation.